### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/xfox111/0ac7129f-7bc1-4680-ac27-c051b8845e31/436eeb75-0389-4cf7-90e3-df95c626852b/_apis/work/boardbadge/c64e9c3a-e4e9-47ec-afd0-9240a2e472b9)](https://dev.azure.com/xfox111/0ac7129f-7bc1-4680-ac27-c051b8845e31/_boards/board/t/436eeb75-0389-4cf7-90e3-df95c626852b/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#402](https://dev.azure.com/xfox111/0ac7129f-7bc1-4680-ac27-c051b8845e31/_workitems/edit/402). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.